### PR TITLE
Add missing 'use strict' directive to tailer.js

### DIFF
--- a/src/install/tailer.js
+++ b/src/install/tailer.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const path = require('path')
 const fs = require('fs-extra')
 const debug = require('debug')('windows-build-tools')


### PR DESCRIPTION
Error installing with Node v4:
```
class Tailer extends EventEmitter {
^^^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```