### PR TITLE
Remove the --global flag from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 On Windows? Want to compile native Node modules? Install the build tools with this one-liner:
 
 ```
-npm install --global --production windows-build-tools
+npm install --global windows-build-tools
 ```
 
 ![Gif](https://cloud.githubusercontent.com/assets/1426799/15993939/2bbb470a-30aa-11e6-9cde-94c39b3f35cb.gif)


### PR DESCRIPTION
We were curious about this, so I published a sample package with a dev dependency on `flat`, which I knew to not exist in my global `node_modules` folders (in %AppData% and Program Files) package.  I then ran npm install without that flag, and checked my global `node modules` folders. My dev dependency was not installed at all. My thought was the --global flag always runs in --production mode.

Reading the [NPM documentation](https://docs.npmjs.com/cli/install), it is unclear whether the `--production` flag applies to `--global` installs. Both flags are only documented under the "(in package directory, no arguments)" section, although `--global` obviously applies to other sections as well.

Furthermore, NPM does very little argument parsing. You can even include non-existent flags, such as: `npm install -g --helloworld @microsoft/generator-sharepoint --microsoft`.

The main reason for bringing this up, is that in our project's README, we tell users to run `npm install -g --production windows-build-tools`, but we would prefer to not have this flag there if it has no effect.

ALSO, thanks for the great work on this project!