### PR TITLE
Fix issue with spaces for python TARGETDIR

### DIFF
--- a/ps1/launch-installer.ps1
+++ b/ps1/launch-installer.ps1
@@ -46,8 +46,8 @@ function runPythonInstaller
     if (Test-Path $path)
     {
         cd $path
-        $pyParams = "/i", "python-2.7.11.msi", "TARGETDIR=`"$path\python27`"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
-        msiexec.exe $pyParams
+        $pyParams = "/i", "python-2.7.11.msi", "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
+        Invoke-Expression "msiexec.exe $pyParams"
     }
 }
 


### PR DESCRIPTION
This fixes an issue with paths that includes spaces such as `C:\Users\My Name\.windows-build-tools\`.

On Windows 7, it previously launched the MSIEXEC help dialog instead of running the python installer. After many hours of trial and error, it appears as though the path needed to be wrapped **with** escaped back ticks, and Invoke-Expression allows the command to be invoked correctly.

Closes #12