### PR TITLE
Update python version to match src/constants.js

### DIFF
--- a/ps1/launch-installer.ps1
+++ b/ps1/launch-installer.ps1
@@ -46,7 +46,7 @@ function runPythonInstaller
     if (Test-Path $path)
     {
         cd $path
-        $pyParams = "/i", "python-2.7.11.msi", "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
+        $pyParams = "/i", "python-2.7.13.msi", "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
         Invoke-Expression "msiexec.exe $pyParams"
     }
 }


### PR DESCRIPTION
When I try to run `npm install --global --production windows-build-tools`, it hangs after installing `Visual Studio Build Tools`:

```
> npm install --global --production windows-build-tools

> windows-build-tools@1.3.1 postinstall C:\Users\username\AppData\Roaming\npm\node_modules\windows-build-tools
> node ./lib/index.js

Downloading BuildTools_Full.exe
Downloading python-2.7.13.msi
[>                                            ] 0.0% (0 B/s)
Downloaded python-2.7.13.msi. Saved to C:\Users\username\.windows-build-tools\python-2.7.13.msi.
Starting installation...
Launched installers, now waiting for them to finish.
This will likely take some time - please be patient!
Waiting for installers... -Successfully installed Visual Studio Build Tools.
Waiting for installers... |
```

I suspect the cause may be the Python version mismatch between `src/constants.js` and `ps1/launch-installer.ps1`.