### PR TITLE
Display python installation status

### DIFF
--- a/ps1/launch-installer.ps1
+++ b/ps1/launch-installer.ps1
@@ -46,7 +46,7 @@ function runPythonInstaller
     if (Test-Path $path)
     {
         cd $path
-        $pyParams = "/i", "python-2.7.13.msi", "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
+        $pyParams = "/i", "python-2.7.13.msi", "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qr", "/L*P", "`"$path\python-log.txt`""
         Invoke-Expression "msiexec.exe $pyParams"
     }
 }


### PR DESCRIPTION
This helps to avoid (or at least get proper error message) issues like #33 , when python installer is failed somewhere and you don't know where :dizzy_face:
