### PR TITLE
Change installer to not hard code python file name

### DIFF
--- a/ps1/launch-installer.ps1
+++ b/ps1/launch-installer.ps1
@@ -2,7 +2,8 @@
 Param(
     [Parameter(Mandatory=$True)]
     [string]$path,
-    [string]$extraBuildToolsParameters
+    [string]$extraBuildToolsParameters,
+    [string]$pythonInstaller
 )
 
 # Returns whether or not the current user has administrative privileges
@@ -46,7 +47,7 @@ function runPythonInstaller
     if (Test-Path $path)
     {
         cd $path
-        $pyParams = "/i", "python-2.7.13.msi", "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
+        $pyParams = "/i", $pythonInstaller, "TARGETDIR=```"$path\python27```"", "ALLUSERS=0", "/qn", "/L*P", "`"$path\python-log.txt`""
         Invoke-Expression "msiexec.exe $pyParams"
     }
 }

--- a/src/install/launch.js
+++ b/src/install/launch.js
@@ -7,6 +7,7 @@ const debug = require('debug')('windows-build-tools')
 
 const utils = require('../utils')
 const installer = utils.getBuildToolsInstallerPath()
+const pythonInstaller = utils.getPythonInstallerPath()
 
 /**
  * Launches the installer, using a PS1 script as a middle-man
@@ -33,7 +34,7 @@ function launchInstaller () {
 
 
     const scriptPath = path.join(__dirname, '..', '..', 'ps1', 'launch-installer.ps1')
-    const psArgs = `& {& '${scriptPath}' -path '${installer.directory}' -extraBuildToolsParameters '${extraArgs}' }`
+    const psArgs = `& {& '${scriptPath}' -path '${installer.directory}' -extraBuildToolsParameters '${extraArgs}' -pythonInstaller '${pythonInstaller.fileName}'}`
     const args = ['-ExecutionPolicy', 'Bypass', '-NoProfile', '-NoLogo', psArgs]
 
     debug(`Installer: Launching installer in ${installer.directory} with file ${installer.fileName}`)

--- a/test/src/install/launch.js
+++ b/test/src/install/launch.js
@@ -30,7 +30,8 @@ describe('Install - Launch', () => {
       .then(() => {
         const expectedScriptPath = path.join(__dirname, '..', '..', '..', 'ps1', 'launch-installer.ps1')
         const expectedInstallerPath = path.join(process.env.USERPROFILE || process.env.HOME, '.windows-build-tools')
-        const expectedPsArgs = `& {& '${expectedScriptPath}' -path '${expectedInstallerPath}' -extraBuildToolsParameters '' }`
+        const expectedPythonInstaller = process.arch === 'x64' ? 'python-2.7.14.amd64.msi' : 'python-2.7.14.msi'
+        const expectedPsArgs = `& {& '${expectedScriptPath}' -path '${expectedInstallerPath}' -extraBuildToolsParameters '' -pythonInstaller '${expectedPythonInstaller}'}`
         const expectedArgs = ['-ExecutionPolicy', 'Bypass', '-NoProfile', '-NoLogo', expectedPsArgs]
 
         passedProcess.should.equal('powershell.exe')


### PR DESCRIPTION
Pass python installer location from utils to have one source for the installer name.

Should resolve a lot of cases of Issues #70 and #47 