### PR TITLE
Fixed the syntax errors due to the destructuring pattern.

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -2,9 +2,9 @@
 
 const nugget = require('nugget')
 
-const { getBuildToolsInstallerPath } = require('./utils/get-build-tools-installer-path')
-const { getPythonInstallerPath } = require('./utils/get-python-installer-path')
-const { log } = require('./logging')
+const getBuildToolsInstallerPath = require('./utils/get-build-tools-installer-path').getBuildToolsInstallerPath
+const getPythonInstallerPath = require('./utils/get-python-installer-path').getPythonInstallerPath
+const log = require('./logging').log
 
 /**
  * Downloads the Visual Studio C++ Build Tools and Python installer to a temporary folder

--- a/src/logging.js
+++ b/src/logging.js
@@ -19,7 +19,7 @@ function warn () {
 }
 
 /**
- * Error, unless logging is disabled. arameters identical with console.error.
+ * Error, unless logging is disabled. Parameters identical with console.error.
  */
 function error () {
   if (!process.env.npm_config_disable_logging) {

--- a/src/utils/get-build-tools-installer-path.js
+++ b/src/utils/get-build-tools-installer-path.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 
-const { getWorkDirectory } = require('./get-work-dir')
+const getWorkDirectory = require('./get-work-dir').getWorkDirectory
 const constants = require('../constants')
 
 /**

--- a/src/utils/get-python-installer-path.js
+++ b/src/utils/get-python-installer-path.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 
-const { getWorkDirectory } = require('./get-work-dir')
+const getWorkDirectory = require('./get-work-dir').getWorkDirectory
 const constants = require('../constants')
 
 /**

--- a/test/src/environment.js
+++ b/test/src/environment.js
@@ -31,7 +31,7 @@ describe('Environment', () => {
     passedProcess = undefined
   })
 
-  it('should attempt to lauch the environment script', (done) => {
+  it('should attempt to launch the environment script', (done) => {
     mockery.registerMock('child_process', cpMock)
     require('../../lib/environment')(variables).should.be.fulfilled
       .then(() => {
@@ -47,7 +47,7 @@ describe('Environment', () => {
       .should.notify(done)
   })
 
-  it('should attempt to lauch the environment script with the add to path variable', (done) => {
+  it('should attempt to launch the environment script with the add to path variable', (done) => {
     mockery.registerMock('child_process', cpMock)
 
     process.env.npm_config_add_python_to_path = true


### PR DESCRIPTION
This should help the AppVeyor build to pass. Also, fixed a few typos.

Just close this PR if you do not need it. Thanks!

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

PS: I have noticed another typo [here](https://github.com/felixrieseberg/windows-build-tools/blob/777dd9e10940a3a145f124081018912f161d12be/src/utils/find-logfile.js#L49), I was just not sure whether it would break something or not. I left as is. `timestap` -> `timestamp`. I can fix that too and squash the commits.