### PR TITLE
Add additional check for successful Visual C++ Build Tools installation

### DIFF
--- a/__tests__/utils/installation-success.ts
+++ b/__tests__/utils/installation-success.ts
@@ -23,6 +23,11 @@ describe('installation-success', () => {
         isPythonSuccess: false
       });
 
+      expect(includesSuccess('Setting string variable \'IsInstalled\' to value \'1\'')).toEqual({
+        isBuildToolsSuccess: true,
+        isPythonSuccess: false
+      });
+
       expect(includesSuccess('Blubblub')).toEqual({
         isBuildToolsSuccess: false,
         isPythonSuccess: false

--- a/src/utils/installation-sucess.ts
+++ b/src/utils/installation-sucess.ts
@@ -8,7 +8,8 @@ export function includesSuccess(input: string = '') {
     // Success strings for build tools (2015)
     isBuildToolsSuccess = input.includes('Variable: IsInstalled = 1') ||
       input.includes('Variable: BuildTools_Core_Installed = ') ||
-      input.includes('WixBundleInstalled = 1');
+      input.includes('WixBundleInstalled = 1') ||
+      input.includes('Setting string variable \'IsInstalled\' to value \'1\'');
   } else {
     // Success strings for build tools (2017)
     isBuildToolsSuccess = input.includes('Closing installer. Return code: 3010.') ||


### PR DESCRIPTION
It appears there is a new string of text being logged in the build-tools-log.txt to indicate that the Visual C++ Build Tools were successfully installed:

> Setting string variable 'IsInstalled' to value '1'

I have added a check for this string to the package's main code and tests alongside the existing string checks.

This PR _may_ (I say may because there may be other possible "magic strings" in the build-tools-log.txt that indicate a successful installation that we are not aware of) fix #103, fix #116, and fix #123.

On my machine, I am now able to install the Build Tools and Python, but the `npm install` process still does not exit after the `All done!` message. This is probably due to the fact that the Build Tools installer processes don't exit after installation (or ever, as far as I can tell). I haven't been able to find out why they don't exit, but at least now we are reporting a successful installation to the user so users know they can safely send ^C to exit the `npm install` process.

As an aside, if someone does figure out how to get the Build Tools installer process to exit at the appropriate time, maybe we can use the process's exit code to determine whether the installation was successful, rather than relying on a number of "magic strings" in the log files.