### PR TITLE
Update Python to 2.7.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ it's installed. Alternatively, you can prepare a folder that contains installers
 have their original names:
 
  * Visual Studio Build Tools: `vs_BuildTools.exe` or `BuildTools_Full.exe`
- * Python: `python-2.7.14.amd64.msi` or `python-2.7.14.msi`
+ * Python: `python-2.7.15.amd64.msi` or `python-2.7.15.msi`
 
 Then, run `windows-build-tools` with the `--offline-installers` argument:
 

--- a/__tests__/utils/get-python-installer-path-test.ts
+++ b/__tests__/utils/get-python-installer-path-test.ts
@@ -14,11 +14,11 @@ describe('getPythonInstallerPath', () => {
 
     expect(getPythonInstallerPath()).toEqual({
       directory: 'C:\\workDir',
-      fileName: `python-2.7.14.${amd64}msi`,
+      fileName: `python-2.7.15.${amd64}msi`,
       logPath: 'C:\\workDir\\python-log.txt',
-      path: `C:\\workDir\\python-2.7.14.${amd64}msi`,
+      path: `C:\\workDir\\python-2.7.15.${amd64}msi`,
       targetPath: 'C:\\workDir\\python27',
-      url: `https://www.python.org/ftp/python/2.7.14/python-2.7.14.${amd64}msi`,
+      url: `https://www.python.org/ftp/python/2.7.15/python-2.7.15.${amd64}msi`,
     });
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,13 +20,13 @@ export const IS_PYTHON_INSTALLED = !!INSTALLED_PYTHON_VERSION;
 
 export const PYTHON = process.arch === 'x64'
   ? {
-    installerName: 'python-2.7.14.amd64.msi',
-    installerUrl: pythonMirror.replace(/\/*$/, '/2.7.14/python-2.7.14.amd64.msi'),
+    installerName: 'python-2.7.15.amd64.msi',
+    installerUrl: pythonMirror.replace(/\/*$/, '/2.7.15/python-2.7.15.amd64.msi'),
     targetName: 'python27',
     logName: 'python-log.txt'
   } : {
-    installerName: 'python-2.7.14.msi',
-    installerUrl: pythonMirror.replace(/\/*$/, '/2.7.14/python-2.7.14.msi'),
+    installerName: 'python-2.7.15.msi',
+    installerUrl: pythonMirror.replace(/\/*$/, '/2.7.15/python-2.7.15.msi'),
     targetName: 'python27',
     logName: 'python-log.txt'
   };


### PR DESCRIPTION
The latest version of Python 2 is 2.7.15 (https://www.python.org/downloads/release/python-2715/). This updates the download links and references.