### PR TITLE
Add ARM64 Windows tool option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Optional arguments:
 * `--silent`: The script will not output any information.
 * `--vs2015`: Install the Visual Studio 2015 Build Tools instead of the Visual Studio 2017 ones.
 * `--dry-run-only`: Don't actually do anything, just print what the script would have done.
+* `--include-arm64-tools`: Include the optional Visual Studio components required to build binaries for ARM64 Windows. Only available with the 2017 and newer build tools and Node.js v12 and up.
 
 ## Supplying Parameters to the VCC Build Tools
 

--- a/src/utils/get-build-tools-parameters.ts
+++ b/src/utils/get-build-tools-parameters.ts
@@ -1,3 +1,5 @@
+import { BUILD_TOOLS } from '../constants';
+
 const debug = require('debug')('windows-build-tools');
 
 export function getBuildToolsExtraParameters() {
@@ -14,6 +16,10 @@ export function getBuildToolsExtraParameters() {
       debug(`Installer: Parsing additional arguments for VCC build tools failed: ${e.message}`);
       debug(`Input received: ${process.env.npm_config_vcc_build_tools_parameters}`);
     }
+  }
+
+  if (!!process.env.npm_config_include_arm64_tools && BUILD_TOOLS.version === 2017) {
+    extraArgs += ' --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64';
   }
 
   return extraArgs;


### PR DESCRIPTION
With support for ARM64 Windows coming soon (https://github.com/nodejs/node/issues/25998), I would like to see the tool that [node-gyp recommends](https://github.com/nodejs/node-gyp/blame/master/README.md#L45) at least offer the option to install the ARM64 libraries needed for building native modules.

The initial version of this change takes a simple approach. I'm happy to rework it completely.

Also, this may be a simple change, but I haven't yet tried it.