### PR TITLE
Ensure consistent return type from setEnvironment

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -14,7 +14,7 @@ const debug = require('debug')('windows-build-tools');
  *
  * @params variables an object with paths for different environmental variables
  */
-export function setEnvironment(env: InstallationDetails) {
+export function setEnvironment(env: InstallationDetails): Promise<void> {
   const scriptPath = IS_DRY_RUN
     ? path.join(__dirname, '..', 'ps1', 'dry-run.ps1')
     : path.join(__dirname, '..', 'ps1', 'set-environment.ps1');
@@ -45,7 +45,8 @@ export function setEnvironment(env: InstallationDetails) {
     log(chalk.bold.green(`Now configuring the Visual Studio Build Tools..`));
   } else {
     log(chalk.bold.green(`Skipping configuration: No configuration for Python or Visual Studio Build Tools required.`));
-    return;
+    return(new Promise((resolve, reject) => resolve()))
+      .then(() => log(chalk.bold.green(`\nAll done!\n`)));
   }
 
   const maybeArgs = `${pythonArguments}${buildArguments}`;


### PR DESCRIPTION
In setEnvironment(), a different type is returned if you are skipping configuration instead of invoking the executeChildProcess.  When the caller attempts to chain off the result you get the following type error:

TypeError: Cannot read property 'then' of undefined

This is the caller code snippet invoking setEnvironment:

`      setEnvironment(variables).then(() => process.exit(0)).catch(() => `process.exit(1));`

TypeError: Cannot read property 'then' of undefined
    at install_1.install (C:\Users\Dave\AppData\Roaming\npm\node_modules\windows-build-tools\dist\start.js:19:17)

Should fix #175 win10 ver17763.316 Could not install Visual Studio Build Tools. 