### PR TITLE
misc: Correct log message if Build Tools Installer cannot be found

### DIFF
--- a/ps1/launch-installer.ps1
+++ b/ps1/launch-installer.ps1
@@ -41,7 +41,7 @@ function runInstaller {
       ./BuildTools_Full.exe $params
     }
   } else {
-    Write-Output "Tried to start Python installer, but couldn't find $BuildToolsInstallerPath."
+    Write-Output "Tried to start Windows Build Tools installer, but couldn't find $BuildToolsInstallerPath."
   }
 }
 

--- a/ps1/launch-installer.ps1
+++ b/ps1/launch-installer.ps1
@@ -41,7 +41,7 @@ function runInstaller {
       ./BuildTools_Full.exe $params
     }
   } else {
-    Write-Output "Tried to start Windows Build Tools installer, but couldn't find $BuildToolsInstallerPath."
+    Write-Output "Tried to start Build Tools installer, but couldn't find $BuildToolsInstallerPath."
   }
 }
 


### PR DESCRIPTION
Seems like a small typo in the log, if it can't find the installer. (Can that even hapepn O.o)