### PR TITLE
Fix setting up PATH environment variable

### DIFF
--- a/ps1/set-environment.ps1
+++ b/ps1/set-environment.ps1
@@ -26,7 +26,7 @@ function configurePython() {
   npm config set python $pythonExePath
 
   # Add Python to path
-  [System.Environment]::SetEnvironmentVariable("Path", "$pythonPath;$env:Path", "User")
+  [System.Environment]::SetEnvironmentVariable("Path", "$pythonPath;" + [System.Environment]::GetEnvironmentVariable("Path", "User"), "User")
   [System.Environment]::SetEnvironmentVariable("Path", "$pythonPath;$env:Path", "Process")
 }
 


### PR DESCRIPTION
Npm is modifying process environment variables before running postinstall script. Especially, it adds `%APPDATA%\npm\node_modules\npm\node_modules\npm-lifecycle\node-gyp-bin` to the PATH variable. This pollutes users PATH variable and for some users breaks node-gyp (e.g.: https://github.com/nodejs/node-gyp/issues/1760, https://github.com/nodejs/node-gyp/issues/1633, but there are more)

This PR makes `set-enviroment.ps1` use users variable value (not the current process one) when adding Python to the users PATH variable.
