### PR TITLE
v5.2.2 fix vs2017 installation endless wait

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windows-build-tools",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Install C++ Build Tools for Windows using npm",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/find-logfile.ts
+++ b/src/utils/find-logfile.ts
@@ -16,7 +16,9 @@ export function findVCCLogFile(): Promise<string> {
     fs.readdir(tmp)
       .then((contents) => {
         // Files that begin with dd_client_
-        const matchingFiles = contents.filter((f) => f.startsWith('dd_client_'));
+        // const matchingFiles = contents.filter((f) => f.startsWith('dd_client_'));
+        const matchingFiles = contents.filter((f) => f.startsWith('dd_installer_'));
+        console.log(matchingFiles)
         let matchingFile = null;
 
         if (matchingFiles && matchingFiles.length === 1) {

--- a/src/utils/find-logfile.ts
+++ b/src/utils/find-logfile.ts
@@ -16,9 +16,7 @@ export function findVCCLogFile(): Promise<string> {
     fs.readdir(tmp)
       .then((contents) => {
         // Files that begin with dd_client_
-        // const matchingFiles = contents.filter((f) => f.startsWith('dd_client_'));
         const matchingFiles = contents.filter((f) => f.startsWith('dd_installer_'));
-        console.log(matchingFiles)
         let matchingFile = null;
 
         if (matchingFiles && matchingFiles.length === 1) {

--- a/src/utils/installation-sucess.ts
+++ b/src/utils/installation-sucess.ts
@@ -19,7 +19,7 @@ export function includesSuccess(input: string = '') {
   } else {
     // Success strings for build tools (2017)
     isBuildToolsSuccess = input.includes('Closing installer. Return code: 3010.') ||
-      input.includes('Closing installer. Return code: 0.');
+      input.includes('Closing installer. Return code: 0.') || input.includes('Closing the installer with exit code 0');
   }
 
   // Success strings for Python


### PR DESCRIPTION
Manually test on windows 10 education edition with node v10.24.1, npm v6.14.12 and `npm install font-scanner`